### PR TITLE
docker-compose.yml example is wrong

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,6 @@ services:
       ADMIN_GOLBAT_API_SECRET: secret
 
       ADMIN_KOJI_API_ENDPOINT: http://koji:8080
-      ADMIN_KOJI_API_BEARER_TOKEN: secret
+      ADMIN_KOJI_BEARER_TOKEN: secret
     ports:
       - '9003:9003'


### PR DESCRIPTION
ADMIN_KOJI_API_BEARER_TOKEN should be ADMIN_KOJI_BEARER_TOKEN